### PR TITLE
docs(cv): add codebar/planner as maintainer

### DIFF
--- a/content/cv/index.md
+++ b/content/cv/index.md
@@ -74,7 +74,8 @@ _Earlier experience: Coop, ZYB, Semler IT, IT-Jobbank, Valtech, Software Innovat
 **Open Source**
 
 - **[idempot-js](https://js.idempot.dev)** — Author, idempotency middleware for Hono, Express, and Fastify with built-in resilience. Implements [IETF draft specification](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07).
-- **Sinon.JS** — Core team member, testing library with 9M+ weekly downloads
+- **[Sinon.JS](https://www.npmjs.com/package/sinon)** — Core team member, testing library with 9M+ weekly downloads
+- **[codebar/planner](https://github.com/codebar/planner/graphs/contributors)** — Maintainer
 
 **Community Leadership**
 


### PR DESCRIPTION
## Summary

- Add codebar/planner as maintainer under Open Source section
- Link to contributors page to show contribution history
- Also added missing link to Sinon.JS GitHub repo for consistency